### PR TITLE
In vehicle routing notebook, make Location + Depot problem facts and include them in solution

### DIFF
--- a/vehicle-routing/vehicle-routing-quickstart.ipynb
+++ b/vehicle-routing/vehicle-routing-quickstart.ipynb
@@ -4,10 +4,10 @@
    "cell_type": "markdown",
    "id": "fb58a9af",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%% md\n"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# OptaPy - OptaPlanner in Python\n",
@@ -48,6 +48,9 @@
    },
    "outputs": [],
    "source": [
+    "from optapy import problem_fact\n",
+    "\n",
+    "@problem_fact\n",
     "class Location:\n",
     "    def __init__(self, latitude, longitude, distance_map=None):\n",
     "        self.latitude = latitude\n",
@@ -100,6 +103,7 @@
    "source": [
     "import math\n",
     "\n",
+    "@problem_fact\n",
     "class EuclideanDistanceCalculator:\n",
     "    METERS_PER_DEGREE = 111_000\n",
     "    \n",
@@ -145,6 +149,7 @@
    },
    "outputs": [],
    "source": [
+    "@problem_fact\n",
     "class Depot:\n",
     "    def __init__(self, name, location):\n",
     "        self.name = name\n",
@@ -177,8 +182,6 @@
    },
    "outputs": [],
    "source": [
-    "from optapy import problem_fact\n",
-    "\n",
     "@problem_fact\n",
     "class Customer:\n",
     "    def __init__(self, name, location, demand):\n",
@@ -446,6 +449,14 @@
     "    @value_range_provider('customer_range', value_range_type=list)\n",
     "    def get_customer_list(self):\n",
     "        return self.customer_list\n",
+    "    \n",
+    "    @problem_fact_collection_property(Location)\n",
+    "    def get_location_list(self):\n",
+    "        return self.location_list\n",
+    "    \n",
+    "    @problem_fact_collection_property(Depot)\n",
+    "    def get_depot_list(self):\n",
+    "        return self.depot_list\n",
     "\n",
     "    @planning_score(HardSoftScore)\n",
     "    def get_score(self):\n",


### PR DESCRIPTION
With the jpyinterpreter work done, Location and Depot need to be known to OptaPy so cloning is done correctly. In particular, because Location is used in a map, and Location does not define __eq__ or __hash__, a Location can only be translated to its Java counterpart once (otherwise, the location cannot be found in the map, since the one in the map would be a different instance than the location queried).